### PR TITLE
Add `frozendict` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'numpy',
         'scipy>=1.4.0',
         'portpicker',
+        'frozendict',
     ],
     tests_require=['nose'],
     python_requires='>=3.6.1',


### PR DESCRIPTION
`frozendict` seems to be used by the code in a few places [1] with no explicit requirement, just adding a missing line to fix install.

[1] https://github.com/deepmind/dm_alchemy/search?q=frozendict